### PR TITLE
Fix: adjust wording on profile

### DIFF
--- a/profile/readme.md
+++ b/profile/readme.md
@@ -10,4 +10,4 @@ Front-end experts with love for the web and the world. Programming from our offi
 Part of our sharing effort are our [open source projects](https://github.com/orgs/voorhoede/repositories?q=open-source) and our [blog posts](https://www.voorhoede.nl/en/blog/). We also love to [contribute to the open source projects](https://opencollective.com/devoorhoede) we depend on daily.
 
 ### 🗺️ B Corp in progress
-We are working very hard to become a B Corp certified company. With this certificate we want to give direction to making our organization more sustainable and more social. B Corp is an international quality mark for profitable companies where people and the environment are central to doing business.
+We are working very hard to become a B Corp certified company. With this certificate we want to give direction to making our organization more sustainable and more socially engaged. B Corp is an international quality mark for profitable companies where people and the environment are central to doing business.


### PR DESCRIPTION
I noticed on our organisation profile it mentions that our b-corp certification will help us be more social. I think within an English context, this means more something like 'gezellig'. I wonder if adjusting it to 'socially engaged' will get closer to the meaning of what we're trying to say.